### PR TITLE
feat(interpreter): add initial structure and boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+
+members = ["interpreter"]

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "interpreter"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/interpreter/src/main.rs
+++ b/interpreter/src/main.rs
@@ -1,0 +1,74 @@
+use std::fs::read_to_string;
+use std::io::prelude::*;
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::process::exit;
+
+struct Rune {
+  had_error: bool,
+}
+
+impl Rune {
+  fn new() -> Self {
+    Rune {
+      had_error: false,
+    }
+  }
+
+  fn run_file(&mut self, path: &String) {
+    let path = Path::new(&path);
+    let buffer = read_to_string(&path).expect("Couldn't read file");
+    self.run(buffer);
+  }
+
+  fn run_prompt(&mut self) {
+    println!("\n‹◊◊ Rune ◊◊›\nMythic power at your fingertips\n");
+    loop {
+      // let mut buffer = String::new();
+      let stdin = io::stdin();
+      for line in stdin.lock().lines() {
+        // println!("{}", line.unwrap());
+
+        match line.unwrap().as_str() {
+          "exit" => {
+            println!("\n");
+            exit(0);
+          }
+          "" => {}
+          _ => {
+            println!("Invalid input");
+          }
+        }
+        print!("» ");
+        io::stdout().flush().unwrap();
+      }
+    }
+  }
+
+  fn run(&mut self, source: String) {
+
+    if self.had_error {
+      println!("Errors!")
+    }
+
+    println!("source: {}", source);
+  }
+}
+
+fn main() {
+  let args: Vec<String> = std::env::args().collect();
+  let mut rune = Rune::new();
+
+  match args.len() {
+    1 => {
+      rune.run_prompt();
+    }
+    2 => {
+      rune.run_file(&args[1]);
+    }
+    _ => {
+      println!("\nUsage: rune [file]\n");
+      exit(64);
+    }
+  }
+}


### PR DESCRIPTION
Added `interpreter` package to the primary workspace.

Added the primary structures for running the interpreter:
- Base `Rune` struct
- `main` function to with basic command line argument parsing
- `run_file` to read source from file
- `run_prompt` to read source from stdin
- `run` to (eventually) invoke the interpreter